### PR TITLE
Remove deprecated API calls relying on the default universe

### DIFF
--- a/cryptomatte/cryptomatte_manifest_driver.cpp
+++ b/cryptomatte/cryptomatte_manifest_driver.cpp
@@ -32,7 +32,7 @@ driver_write_bucket {}
 driver_close {
     CryptomatteData* data = (CryptomatteData*)AiNodeGetLocalData(node);
     if (data)
-        data->write_sidecar_manifests();
+        data->write_sidecar_manifests(AiNodeGetUniverse(node));
 }
 
 node_finish {}

--- a/cryptomatte/cryptomatte_shader.cpp
+++ b/cryptomatte/cryptomatte_shader.cpp
@@ -71,6 +71,7 @@ node_finish {
 
 node_update {
     CryptomatteData* data = reinterpret_cast<CryptomatteData*>(AiNodeGetLocalData(node));
+    AtUniverse *universe = AiNodeGetUniverse(node);
 
     data->set_option_sidecar_manifests(AiNodeGetBool(node, "sidecar_manifests"));
     data->set_option_channels(AiNodeGetInt(node, "cryptomatte_depth"),
@@ -107,7 +108,7 @@ node_update {
                                     AiNodeGetStr(node, "user_crypto_src_2").c_str(),
                                     AiNodeGetStr(node, "user_crypto_src_3").c_str());
 
-    data->setup_all(AiNodeGetStr(node, "aov_crypto_asset"), AiNodeGetStr(node, "aov_crypto_object"),
+    data->setup_all(universe, AiNodeGetStr(node, "aov_crypto_asset"), AiNodeGetStr(node, "aov_crypto_object"),
                     AiNodeGetStr(node, "aov_crypto_material"), uc_aov_array, uc_src_array);
 }
 


### PR DESCRIPTION
As explained in #3 , the following functions need an additional AtUniverse argument :

- AiNodeLookUpByName
- AiUniverseGetOptions 
- AiNode 
- AiUniverseGetNodeIterator

This PR ensures that the proper universe is called everywhere is needed, and thus removes the deprecated API calls.
This requires to pass this universe from function to function all along, but it's needed in order to be correct.
I've verified that this compiles, but haven't managed to run the tests. In theory, all the tests should are relying on a default (null) universe, which shouldn't make any difference after these changes.
