### PR TITLE
Add support for custom output drivers

### DIFF
--- a/cryptomatte/cryptomatte_shader.cpp
+++ b/cryptomatte/cryptomatte_shader.cpp
@@ -15,6 +15,8 @@ enum cryptomatteParams {
     p_aov_crypto_object,
     p_aov_crypto_material,
     p_preview_in_exr,
+    p_custom_output_driver,
+    p_create_depth_outputs,
     p_process_maya,
     p_process_paths,
     p_process_obj_path_pipes,
@@ -39,6 +41,8 @@ node_parameters {
     AiParameterStr("aov_crypto_object", "crypto_object");
     AiParameterStr("aov_crypto_material", "crypto_material");
     AiParameterBool("preview_in_exr", CRYPTO_PREVIEWINEXR_DEFAULT);
+    AiParameterBool("custom_output_driver", false);
+    AiParameterBool("create_depth_outputs", true);
     AiParameterBool("process_maya", true);
     AiParameterBool("process_paths", true);
     AiParameterBool("process_obj_path_pipes", true);
@@ -108,8 +112,14 @@ node_update {
                                     AiNodeGetStr(node, "user_crypto_src_2").c_str(),
                                     AiNodeGetStr(node, "user_crypto_src_3").c_str());
 
-    data->setup_all(universe, AiNodeGetStr(node, "aov_crypto_asset"), AiNodeGetStr(node, "aov_crypto_object"),
-                    AiNodeGetStr(node, "aov_crypto_material"), uc_aov_array, uc_src_array);
+    data->setup_all(universe, 
+                    AiNodeGetStr(node, "aov_crypto_asset"), 
+                    AiNodeGetStr(node, "aov_crypto_object"),
+                    AiNodeGetStr(node, "aov_crypto_material"), 
+                    uc_aov_array, 
+                    uc_src_array, 
+                    AiNodeGetBool(node, "custom_output_driver"), 
+                    AiNodeGetBool(node, "create_depth_outputs"));
 }
 
 shader_evaluate {


### PR DESCRIPTION
This PR adds support for custom output drivers, and is working properly in Houdini Solaris.
We're adding 2 parameters to the cryptomatte shader, that are meant to be used internally and not exposed to the user.

- `custom_output_driver` :  This parameter tells cryptomatte that other drivers than `driver_exr` need to be considered as valid output drivers. The changes for that are
          1.  The test done in `check_driver` will return true in that case, whatever the driver type is.
          2. When setting/getting parameters that usually exist in `driver_exr` (half_precision, filename, custom_attributes, compression), we first check if the parameter exists in the driver. 
          3. We want metadatas to be authored in the driver. If `custom_attributes` doesn't exist as an attribute, we create it as a user data

- `create_depth_outputs` :  currently the cryptomatte shader creates new outputs on the fly, depending on the depth attribute. But in some use cases, the scene could already setup these AOVs, and wouldn't want cryptomatte to change the outputs on the fly (which is not a great workflow, a simple shader isn't supposed to change global settings). When this attribute is disabled, we just skip the creation of new outputs. Note that we still need to call `AiAOVRegister` and to set the name of the "rank" AOV in the crypto_aovs array.

These 2 attributes have defaults that don't change the current behaviour, so adding them isn't supposed to break anything.
