### PR TITLE
Support layer tokens in outputs

### DIFF
--- a/cryptomatte/cryptomatte.h
+++ b/cryptomatte/cryptomatte.h
@@ -1020,6 +1020,10 @@ private:
             filter_tok = has_camera ? c3 : c2;
             driver_tok = has_camera ? c4 : c3;
             layer_tok = has_camera ? c5 : c4;
+            // Ensure we're not confusing the optional layer token
+            //  with the (also optional) HALF flag
+            if (layer_tok == String("HALF"))
+                layer_tok = String("");
 
             driver = AiNodeLookUpByName(universe, driver_tok.c_str());
         }

--- a/cryptomatte/cryptomatte_shader.cpp
+++ b/cryptomatte/cryptomatte_shader.cpp
@@ -15,6 +15,8 @@ enum cryptomatteParams {
     p_aov_crypto_object,
     p_aov_crypto_material,
     p_preview_in_exr,
+    p_custom_output_driver,
+    p_create_depth_outputs,
     p_process_maya,
     p_process_paths,
     p_process_obj_path_pipes,
@@ -39,6 +41,8 @@ node_parameters {
     AiParameterStr("aov_crypto_object", "crypto_object");
     AiParameterStr("aov_crypto_material", "crypto_material");
     AiParameterBool("preview_in_exr", CRYPTO_PREVIEWINEXR_DEFAULT);
+    AiParameterBool("custom_output_driver", false);
+    AiParameterBool("create_depth_outputs", true);
     AiParameterBool("process_maya", true);
     AiParameterBool("process_paths", true);
     AiParameterBool("process_obj_path_pipes", true);
@@ -108,8 +112,14 @@ node_update {
                                     AiNodeGetStr(node, "user_crypto_src_2").c_str(),
                                     AiNodeGetStr(node, "user_crypto_src_3").c_str());
 
-    data->setup_all(universe, AiNodeGetStr(node, "aov_crypto_asset"), AiNodeGetStr(node, "aov_crypto_object"),
-                    AiNodeGetStr(node, "aov_crypto_material"), uc_aov_array, uc_src_array);
+    data->setup_all(universe, 
+                    AiNodeGetStr(node, "aov_crypto_asset"), 
+                    AiNodeGetStr(node, "aov_crypto_object"),
+                    AiNodeGetStr(node, "aov_crypto_material"), 
+                    uc_aov_array, 
+                    uc_src_array, 
+                    AiNodeGetBool(node, "custom_output_driver"), 
+                    AiNodeGetBool(node, "create_depth_outputs"));
 }
 
 shader_evaluate {


### PR DESCRIPTION
**This PR requires #7 to be merged first**  as it's based on this branch. Reason is that part of the code that has to be added for the layers is in a chunk that is modified by the first PR.

Apart from the changes in #7 , the changes here are that we're adding one more token in `TokenizedOutputs` called `layer_tok` and we're reading one more token `c6`.
We need to make the tokens "testing" more robust, since there are several optional tokens that make the logic a bit complicated.
The rationale is as follow : 
- the first token can eventually be a camera. To verify this, we check if there is such a node in the current universe, and if it's a camera. In that case `c0` is the camera, `c1` the AOV name, etc.. otherwise `c0` is the AOV name.
- the following mandatory tokens are always "aov name", "aov type", "filter name", "driver name"
- the last token can eventually be `HALF` to specify that this AOV is meant to be half precision
- After the mandatory tokens, but before the eventual HALF token, there can be a token for the layer name.

This PR reproduces this logic parsing the output lines.

Note that, in `setup_new_outputs` when we create the "rank" AOVs (e.g. crypto_material00, crypto_object01, etc...) we copy the "parent" AOV (e.g. crypto_material) and modify the aov name and filter. Now, if a layer name is present we also need to modify it, otherwise this new output would conflict with the parent one. The logic I'm using here is to add the same "rank" suffix to the layer than the one we add to the AOV.  So if `crypto_material` has a layer name called `kryptonite`, then `crypto_material00` will have a layer name set to `kryptonite00`, etc...

In theory, this PR shouldn't change anything when no layer name token is present, but it does change the logic of parsing the outputs, so it needs to be tested carefully to ensure it's not causing any regression


