### PR TITLE
Remove deprecated AtCritSec and replace with AtMutex.

### DIFF
--- a/cryptomatte/cryptomatte.cpp
+++ b/cryptomatte/cryptomatte.cpp
@@ -2,10 +2,7 @@
 #include "MurmurHash3.h"
 #include <ai.h>
 
-AtCritSec g_critsec;
-bool g_critsec_active;
-inline bool crypto_crit_sec_init();
-inline void crypto_crit_sec_close();
+AtMutex g_critsec;
 inline void crypto_crit_sec_enter();
 inline void crypto_crit_sec_leave();
 

--- a/cryptomatte/cryptomatte_shader.cpp
+++ b/cryptomatte/cryptomatte_shader.cpp
@@ -58,9 +58,9 @@ node_parameters {
     AiParameterStr("user_crypto_src_3", "");
 }
 
-node_plugin_initialize { return crypto_crit_sec_init(); }
+node_plugin_initialize { return true; }
 
-node_plugin_cleanup { crypto_crit_sec_close(); }
+node_plugin_cleanup { }
 
 node_initialize {
     CryptomatteData* data = new CryptomatteData();

--- a/cryptomatte/cryptomatte_tests.h
+++ b/cryptomatte/cryptomatte_tests.h
@@ -336,14 +336,6 @@ inline void run() {
 }
 
 } // namespace HashingTests
-namespace SystemTests {
-inline void critical_section() {
-    if (!g_critsec_active)
-        AiMsgError("Crit section was not initialized in plugin init.");
-}
-
-inline void run() { critical_section(); }
-} // namespace SystemTests
 
 inline void run_all_unit_tests(AtNode* node) {
     if (node && AiNodeLookUpUserParameter(node, CRYPTO_TEST_FLAG) &&
@@ -352,7 +344,6 @@ inline void run_all_unit_tests(AtNode* node) {
         NameParsingTests::run();
         HashingTests::run();
         MaterialNameTests::run();
-        SystemTests::run();
         AiMsgWarning("Cryptomatte unit tests: Complete");
     }
 }


### PR DESCRIPTION
`AtCritSec` was deprecated and replaced with `AtMutex` in Arnold 6.0.4 (release notes: https://help.autodesk.com/view/ARNOL/ENU/?guid=arnold_user_guide_ac_release_notes_ac_rn_6040_html). This is essentially a `std::mutex` and is easier to use since it has a constructor and destructor so there's no need to init/close.