### PR TITLE
sidecar manifests are created even if there are no new outputs

### DIFF
--- a/cryptomatte/cryptomatte.h
+++ b/cryptomatte/cryptomatte.h
@@ -1084,12 +1084,11 @@ private:
             outputs_orig[i] = t_output;
         }
 
+        if (option_sidecar_manifests && (outputs_new.size() + outputs_orig.size()) > 0) {
+            AtNode* manifest_driver = setup_manifest_driver(universe);
+            outputs_new.push_back(TokenizedOutput(universe, manifest_driver));
+        }
         if (outputs_new.size()) {
-            if (option_sidecar_manifests) {
-                AtNode* manifest_driver = setup_manifest_driver(universe);
-                outputs_new.push_back(TokenizedOutput(universe, manifest_driver));
-            }
-
             for (auto& t_output : outputs_orig) {
                 // if outputs are not flagged as half, and their drivers are switched
                 // to full float, the output must be set to half to preserve behavior.

--- a/cryptomatte/cryptomatte.h
+++ b/cryptomatte/cryptomatte.h
@@ -1043,7 +1043,7 @@ private:
         std::vector<std::vector<AtNode*>> tmp_uc_drivers(user_cryptomattes.count);
 
         std::vector<TokenizedOutput> outputs_orig(prev_output_num), outputs_new;
-
+        int crypto_aovs_count = 0;
         for (uint32_t i = 0; i < prev_output_num; i++) {
             TokenizedOutput t_output(universe, AiArrayGetStr(outputs, i));
             AtNode* driver = t_output.get_driver();
@@ -1069,6 +1069,7 @@ private:
             }
 
             if (crypto_aovs && check_driver(driver)) {
+                crypto_aovs_count++;
                 setup_new_outputs(universe, t_output, crypto_aovs, outputs_new);
 
                 if (AiNodeEntryLookUpParameter(AiNodeGetNodeEntry(driver), "half_precision")) {
@@ -1084,7 +1085,7 @@ private:
             outputs_orig[i] = t_output;
         }
 
-        if (option_sidecar_manifests && (outputs_new.size() + outputs_orig.size()) > 0) {
+        if (option_sidecar_manifests && crypto_aovs_count) {
             AtNode* manifest_driver = setup_manifest_driver(universe);
             outputs_new.push_back(TokenizedOutput(universe, manifest_driver));
         }


### PR DESCRIPTION
We found an issue where the sidecar manifests are not created when the cryptomatte aovs are defined in the scene.
I believe the cryptomatte shader use to create cryptomatte aovs dynamically at render time, but now they might have been created by the user, this is how it works in solaris/htoa.
However the code doesn't run the sidecar manifest creation if the cryptomatte aovs were not created by the shaders. 
This PR fixes this issue and allows the creation of sidecar manifests regardless of how the outputs aovs were created.
